### PR TITLE
Fix mobile layout on resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "portfolio",
-	"version": "1.5.1",
+	"version": "1.6.0",
 	"description": "A static porfolio for Adrien D. Ahlqvist",
 	"author": "Adrien D. Ahlqvist",
 	"license": "MIT",

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -29,6 +29,6 @@ $mobileWidth: 600px;
 %mainSection__mobile {
 	@media screen and (max-width: $mobileWidth) {
 		margin: 20px;
-		margin-right: 0;
+		margin-left: 0;
 	}
 }


### PR DESCRIPTION
### Current behaviour
On mobile, the resume has too much margin on the right
![Screenshot_20200128-121546](https://user-images.githubusercontent.com/8983461/73466333-b9636e00-434f-11ea-93dc-981b0636f649.png)
